### PR TITLE
remove need for special bindings for wire spawning

### DIFF
--- a/Connected/Assets/Prefabs/WireSpawner.prefab
+++ b/Connected/Assets/Prefabs/WireSpawner.prefab
@@ -44,10 +44,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   LeftHandPressed:
-    actionPath: /actions/default/in/LeftHandTrigger
+    actionPath: /actions/default/in/Squeeze
     needsReinit: 0
   RightHandPressed:
-    actionPath: /actions/default/in/RightHandTrigger
+    actionPath: /actions/default/in/Squeeze
     needsReinit: 0
   wirePrefab: {fileID: 4651223236595471121, guid: 71f4a1d08bb81a1459953763dd9c7523, type: 3}
   player: {fileID: 0}

--- a/Connected/Assets/Scenes/HelloWorld.unity
+++ b/Connected/Assets/Scenes/HelloWorld.unity
@@ -1340,7 +1340,7 @@ Transform:
   - {fileID: 2047926004}
   - {fileID: 979565307}
   m_Father: {fileID: 0}
-  m_RootOrder: 15
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1502849406
 GameObject:
@@ -1459,57 +1459,6 @@ PrefabInstance:
       objectReference: {fileID: 2100000, guid: 70a2eb634d7ed434b86d36f190fcf3a1, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dc06161b6d97feb419f45f03b62e14b9, type: 3}
---- !u!1 &1639026902
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1639026904}
-  - component: {fileID: 1639026903}
-  m_Layer: 0
-  m_Name: WireSpawner
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1639026903
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1639026902}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ca67588c807d5134a92bce86c3eb8765, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  LeftHandPressed:
-    actionPath: /actions/default/in/LeftHandTrigger
-    needsReinit: 0
-  RightHandPressed:
-    actionPath: /actions/default/in/RightHandTrigger
-    needsReinit: 0
-  wirePrefab: {fileID: 4651223236595471121, guid: 71f4a1d08bb81a1459953763dd9c7523, type: 3}
-  player: {fileID: 900462443}
---- !u!4 &1639026904
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1639026902}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 16
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1663246876
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Connected/Assets/SteamVR_Input/ActionSetClasses/SteamVR_Input_ActionSet_default.cs
+++ b/Connected/Assets/SteamVR_Input/ActionSetClasses/SteamVR_Input_ActionSet_default.cs
@@ -105,30 +105,6 @@ namespace Valve.VR
             }
         }
         
-        public virtual SteamVR_Action_Boolean SpawnWire
-        {
-            get
-            {
-                return SteamVR_Actions.default_SpawnWire;
-            }
-        }
-        
-        public virtual SteamVR_Action_Single LeftHandTrigger
-        {
-            get
-            {
-                return SteamVR_Actions.default_LeftHandTrigger;
-            }
-        }
-        
-        public virtual SteamVR_Action_Single RightHandTrigger
-        {
-            get
-            {
-                return SteamVR_Actions.default_RightHandTrigger;
-            }
-        }
-        
         public virtual SteamVR_Action_Vibration Haptic
         {
             get

--- a/Connected/Assets/SteamVR_Input/SteamVR_Input_Actions.cs
+++ b/Connected/Assets/SteamVR_Input/SteamVR_Input_Actions.cs
@@ -39,12 +39,6 @@ namespace Valve.VR
         
         private static SteamVR_Action_Boolean p_default_SnapTurnRight;
         
-        private static SteamVR_Action_Boolean p_default_SpawnWire;
-        
-        private static SteamVR_Action_Single p_default_LeftHandTrigger;
-        
-        private static SteamVR_Action_Single p_default_RightHandTrigger;
-        
         private static SteamVR_Action_Vibration p_default_Haptic;
         
         private static SteamVR_Action_Vector2 p_platformer_Move;
@@ -149,30 +143,6 @@ namespace Valve.VR
             }
         }
         
-        public static SteamVR_Action_Boolean default_SpawnWire
-        {
-            get
-            {
-                return SteamVR_Actions.p_default_SpawnWire.GetCopy<SteamVR_Action_Boolean>();
-            }
-        }
-        
-        public static SteamVR_Action_Single default_LeftHandTrigger
-        {
-            get
-            {
-                return SteamVR_Actions.p_default_LeftHandTrigger.GetCopy<SteamVR_Action_Single>();
-            }
-        }
-        
-        public static SteamVR_Action_Single default_RightHandTrigger
-        {
-            get
-            {
-                return SteamVR_Actions.p_default_RightHandTrigger.GetCopy<SteamVR_Action_Single>();
-            }
-        }
-        
         public static SteamVR_Action_Vibration default_Haptic
         {
             get
@@ -251,9 +221,6 @@ namespace Valve.VR
                     SteamVR_Actions.default_HeadsetOnHead,
                     SteamVR_Actions.default_SnapTurnLeft,
                     SteamVR_Actions.default_SnapTurnRight,
-                    SteamVR_Actions.default_SpawnWire,
-                    SteamVR_Actions.default_LeftHandTrigger,
-                    SteamVR_Actions.default_RightHandTrigger,
                     SteamVR_Actions.default_Haptic,
                     SteamVR_Actions.platformer_Move,
                     SteamVR_Actions.platformer_Jump,
@@ -274,9 +241,6 @@ namespace Valve.VR
                     SteamVR_Actions.default_HeadsetOnHead,
                     SteamVR_Actions.default_SnapTurnLeft,
                     SteamVR_Actions.default_SnapTurnRight,
-                    SteamVR_Actions.default_SpawnWire,
-                    SteamVR_Actions.default_LeftHandTrigger,
-                    SteamVR_Actions.default_RightHandTrigger,
                     SteamVR_Actions.platformer_Move,
                     SteamVR_Actions.platformer_Jump,
                     SteamVR_Actions.buggy_Steering,
@@ -299,14 +263,11 @@ namespace Valve.VR
                     SteamVR_Actions.default_HeadsetOnHead,
                     SteamVR_Actions.default_SnapTurnLeft,
                     SteamVR_Actions.default_SnapTurnRight,
-                    SteamVR_Actions.default_SpawnWire,
                     SteamVR_Actions.platformer_Jump,
                     SteamVR_Actions.buggy_Brake,
                     SteamVR_Actions.buggy_Reset};
             Valve.VR.SteamVR_Input.actionsSingle = new Valve.VR.SteamVR_Action_Single[] {
                     SteamVR_Actions.default_Squeeze,
-                    SteamVR_Actions.default_LeftHandTrigger,
-                    SteamVR_Actions.default_RightHandTrigger,
                     SteamVR_Actions.buggy_Throttle};
             Valve.VR.SteamVR_Input.actionsVector2 = new Valve.VR.SteamVR_Action_Vector2[] {
                     SteamVR_Actions.platformer_Move,
@@ -324,9 +285,6 @@ namespace Valve.VR
                     SteamVR_Actions.default_HeadsetOnHead,
                     SteamVR_Actions.default_SnapTurnLeft,
                     SteamVR_Actions.default_SnapTurnRight,
-                    SteamVR_Actions.default_SpawnWire,
-                    SteamVR_Actions.default_LeftHandTrigger,
-                    SteamVR_Actions.default_RightHandTrigger,
                     SteamVR_Actions.platformer_Move,
                     SteamVR_Actions.platformer_Jump,
                     SteamVR_Actions.buggy_Steering,
@@ -348,9 +306,6 @@ namespace Valve.VR
             SteamVR_Actions.p_default_HeadsetOnHead = ((SteamVR_Action_Boolean)(SteamVR_Action.Create<SteamVR_Action_Boolean>("/actions/default/in/HeadsetOnHead")));
             SteamVR_Actions.p_default_SnapTurnLeft = ((SteamVR_Action_Boolean)(SteamVR_Action.Create<SteamVR_Action_Boolean>("/actions/default/in/SnapTurnLeft")));
             SteamVR_Actions.p_default_SnapTurnRight = ((SteamVR_Action_Boolean)(SteamVR_Action.Create<SteamVR_Action_Boolean>("/actions/default/in/SnapTurnRight")));
-            SteamVR_Actions.p_default_SpawnWire = ((SteamVR_Action_Boolean)(SteamVR_Action.Create<SteamVR_Action_Boolean>("/actions/default/in/SpawnWire")));
-            SteamVR_Actions.p_default_LeftHandTrigger = ((SteamVR_Action_Single)(SteamVR_Action.Create<SteamVR_Action_Single>("/actions/default/in/LeftHandTrigger")));
-            SteamVR_Actions.p_default_RightHandTrigger = ((SteamVR_Action_Single)(SteamVR_Action.Create<SteamVR_Action_Single>("/actions/default/in/RightHandTrigger")));
             SteamVR_Actions.p_default_Haptic = ((SteamVR_Action_Vibration)(SteamVR_Action.Create<SteamVR_Action_Vibration>("/actions/default/out/Haptic")));
             SteamVR_Actions.p_platformer_Move = ((SteamVR_Action_Vector2)(SteamVR_Action.Create<SteamVR_Action_Vector2>("/actions/platformer/in/Move")));
             SteamVR_Actions.p_platformer_Jump = ((SteamVR_Action_Boolean)(SteamVR_Action.Create<SteamVR_Action_Boolean>("/actions/platformer/in/Jump")));

--- a/Connected/Assets/StreamingAssets/SteamVR/actions.json
+++ b/Connected/Assets/StreamingAssets/SteamVR/actions.json
@@ -50,21 +50,6 @@
       "type": "boolean"
     },
     {
-      "name": "/actions/default/in/SpawnWire",
-      "type": "boolean",
-      "requirement": "suggested"
-    },
-    {
-      "name": "/actions/default/in/LeftHandTrigger",
-      "type": "vector1",
-      "requirement": "mandatory"
-    },
-    {
-      "name": "/actions/default/in/RightHandTrigger",
-      "type": "vector1",
-      "requirement": "mandatory"
-    },
-    {
       "name": "/actions/default/out/Haptic",
       "type": "vibration"
     },


### PR DESCRIPTION
By using the built-in _squeeze_ input action, we can avoid using custom bindings, this has been verified´in VR.